### PR TITLE
fix: remove force redownload

### DIFF
--- a/src/Sergen.Core/GameServers/minecraft.json
+++ b/src/Sergen.Core/GameServers/minecraft.json
@@ -6,8 +6,7 @@
     "25565": "tcp"
     },
     "environmentalVariables": {
-        "EULA": "TRUE",
-        "FORCE_REDOWNLOAD": "True"
+        "EULA": "TRUE"
     },
     "binds": [
         "/data"


### PR DESCRIPTION
Removes `FORCE_REDOWNLOAD` option meaning docker container will re-use the existing server.jar instead of redownloading it on every start-up.

As a side effect the server will not be automatically updated on start-up.